### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,2 +1,2 @@
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: "ubuntu-16.04"


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.