### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,10 @@ steps:
     scannerMode: 'MSBuild'
     projectKey: 'e8bb8df766997f2a78c2603fed2bd30614fd36e5'
     projectName: 'mslearningwebspace'
+- task: SonarCloudAnalyze@1
+- task: SonarCloudPublish@1
+  inputs:
+    pollingTimeoutSec: '300'
 - task: DotNetCoreCLI@2
   displayName: 'Run unit tests - $(buildConfiguration)'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,13 @@ steps:
     command: custom
     custom: tool
     arguments: 'install --global dotnet-reportgenerator-globaltool'
-
+- task: SonarCloudPrepare@1
+  inputs:
+    SonarCloud: 'RohCloudSonarConnection'
+    organization: 'ptlearningruben'
+    scannerMode: 'MSBuild'
+    projectKey: 'e8bb8df766997f2a78c2603fed2bd30614fd36e5'
+    projectName: 'mslearningwebspace'
 - task: DotNetCoreCLI@2
   displayName: 'Run unit tests - $(buildConfiguration)'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,12 +42,7 @@ steps:
     arguments: '--no-restore --configuration $(buildConfiguration)'
     projects: '**/*.csproj'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Install ReportGenerator'
-  inputs:
-    command: custom
-    custom: tool
-    arguments: 'install --global dotnet-reportgenerator-globaltool'
+
 - task: SonarCloudPrepare@1
   inputs:
     SonarCloud: 'RohCloudSonarConnection'
@@ -59,6 +54,13 @@ steps:
 - task: SonarCloudPublish@1
   inputs:
     pollingTimeoutSec: '300'
+- task: DotNetCoreCLI@2
+  displayName: 'Install ReportGenerator'
+  inputs:
+    command: custom
+    custom: tool
+    arguments: 'install --global dotnet-reportgenerator-globaltool'
+    
 - task: DotNetCoreCLI@2
   displayName: 'Run unit tests - $(buildConfiguration)'
   inputs:


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.