### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ steps:
   displayName: 'Run SonarCloud code analysis'
 
 - task: SonarCloudPublish@1
-  displayName: 'Publish SonarCloud quality gate'
+  displayName: 'Publish SonarCloud quality gate check'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage report'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,11 @@ steps:
   inputs:
     version: '$(dotnetSdkVersion)'
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 3.1.505 for SonarCloud'
+  inputs:
+    version: '3.1.100'
+
 - task: Npm@1
   displayName: 'Run npm install'
   inputs:
@@ -38,6 +43,19 @@ steps:
     command: 'restore'
     projects: '**/*.csproj'
 
+- task: SonarCloudPrepare@1
+  displayName: 'Prepare SonarCloud analysis'
+  inputs:
+    SonarCloud: 'SonarCloud connection 1'
+    organization: ' barani3090'
+    scannerMode: 'MSBuild'
+    projectKey: ' barani3090_mslearn-tailspin-spacegame-web'
+    projectName: ' barani3090_mslearn-tailspin-spacegame-web'
+    projectVersion: '$(Build.BuildNumber)'
+    extraProperties: |
+     sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/TestResults/Coverage/coverage.opencover.xml
+     sonar.exclusions=**/wwwroot/lib/**/*
+
 - task: DotNetCoreCLI@2
   displayName: 'Build the project - $(buildConfiguration)'
   inputs:
@@ -56,13 +74,19 @@ steps:
   displayName: 'Run unit tests - $(buildConfiguration)'
   inputs:
     command: 'test'
-    arguments: '--no-build --configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
+    arguments: '--no-build --configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat="cobertura%2copencover" /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
     publishTestResults: true
     projects: '**/*.Tests.csproj'
 
 - script: |
     reportgenerator -reports:$(Build.SourcesDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage -reporttypes:HtmlInline_AzurePipelines
   displayName: 'Create code coverage report'
+
+- task: SonarCloudAnalyze@1
+  displayName: 'Run SonarCloud code analysis'
+
+- task: SonarCloudPublish@1
+  displayName: 'Publish SonarCloud quality gate results'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage report'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ steps:
   displayName: 'Run SonarCloud code analysis'
 
 - task: SonarCloudPublish@1
-  displayName: 'Publish SonarCloud quality gate results'
+  displayName: 'Publish SonarCloud quality gate'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage report'


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.