### PR TITLE
Update azure-pipelines.yml to correct SDK version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '2.1.505'
+  dotnetSdkVersion: '3.1.100'
 
 steps:
 - task: DotNetCoreInstaller@0


### PR DESCRIPTION
As the project files are updated to SDK version 3.1, the pipeline will break, if not changed to SDK version 3.1.