### PR TITLE
Fix broken Azure pipeline file for .NET Core 3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,10 +9,10 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '2.1.505'
+  dotnetSdkVersion: '3.1.102'
 
 steps:
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Use .NET Core SDK $(dotnetSdkVersion)'
   inputs:
     version: '$(dotnetSdkVersion)'


### PR DESCRIPTION
I have been following [this](https://docs.microsoft.com/en-us/learn/modules/run-quality-tests-build-pipeline/4-add-unit-tests) but ran into a problem when executing a pipeline job after checking out the MicrosoftDocs mslearn-tailspin-spacegame-web unit-tests branch. It appears that the dotnetSdkVersion wasn't updated in the pipeline yml after the app was upgraded to 3.1.

Making these changes fixes the problem.