### PR TITLE
Update DotNetCoreInstaller task to UseDotNet

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,10 +9,10 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '2.1.505'
+  dotnetSdkVersion: '3.1.200'
 
 steps:
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Use .NET Core SDK $(dotnetSdkVersion)'
   inputs:
     version: '$(dotnetSdkVersion)'


### PR DESCRIPTION
DotNetCoreInstaller@0 task results in "Restore project dependencies" DotNetCoreCLI@2 task failing. Updating DotNetCoreInstaller task to UseDotNet fixes the issue.