### PR TITLE
[Bugfix] Use .NET core 3.1 like in the moduls exercise

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,10 +9,10 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '2.1.505'
+  dotnetSdkVersion: '3.1.202'
 
 steps:
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   displayName: 'Use .NET Core SDK $(dotnetSdkVersion)'
   inputs:
     version: '$(dotnetSdkVersion)'


### PR DESCRIPTION
In the module at https://docs.microsoft.com/en-us/learn/modules/run-quality-tests-build-pipeline/4-add-unit-tests the pipeline uses .NET core 3.1.100. Upgrading .NET core also requires upgrade of the installer task in the pipeline.