### PR TITLE
Fixed SDK Version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '2.1.505'
+  dotnetSdkVersion: '3.1.100'
 
 steps:
 - task: DotNetCoreInstaller@0


### PR DESCRIPTION
There is a problem with Unit 4 of Course in [Build applications with Azure DevOps Run - quality tests in your build pipeline by using Azure Pipelines](https://docs.microsoft.com/en-us/learn/modules/run-quality-tests-build-pipeline/4-add-unit-tests), regarding of the SDK Version failing on the pipeline.
You should update the version to 3.1.100.