### PR TITLE
Correct .net core 3.1 sdk version and correct DotNetCoreInstaller task version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,10 +9,10 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '2.1.505'
+  dotnetSdkVersion: '3.1.300'
 
 steps:
-- task: DotNetCoreInstaller@0
+- task: DotNetCoreInstaller@2
   displayName: 'Use .NET Core SDK $(dotnetSdkVersion)'
   inputs:
     version: '$(dotnetSdkVersion)'


### PR DESCRIPTION
The unit test branch was updated to use .Net core 3.1 SDK but the version in azure-pipelines was not up to date.

Also `DotNetCoreInstaller@0` cannot handle .NET Core 3.1, instead `DotNetCoreInstaller@2` must be used