### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
+[![Build Status](https://dev.azure.com/singh1836/Space%20Game%20-%20web%20-%20Workflow/_apis/build/status/mslearn-tailspin-spacegame-web?branchName=master)](https://dev.azure.com/singh1836/Space%20Game%20-%20web%20-%20Workflow/_build/latest?definitionId=2&branchName=master)
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,17 @@
+# ASP.NET Core
+# Build and test ASP.NET Core projects targeting .NET Core.
+# Add steps that run tests, create a NuGet package, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  buildConfiguration: 'Release'
+
+steps:
+- script: dotnet build --configuration $(buildConfiguration)
+  displayName: 'dotnet build $(buildConfiguration)'


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.