### PR TITLE
Test project version bump to dotnet 6.0

### DIFF
--- a/Tailspin.SpaceGame.Web.Tests/Tailspin.SpaceGame.Web.Tests.csproj
+++ b/Tailspin.SpaceGame.Web.Tests/Tailspin.SpaceGame.Web.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ProjectGuid>{773BA444-0D67-4F37-8762-17E108CCD5F5}</ProjectGuid>
   </PropertyGroup>


### PR DESCRIPTION
@tpetchel this is a legitimate PR to fix the dotnet version in the Test project for this branch that the MS Learn exercise relies on