### PR TITLE
bump Pipeline from dotnet 5 to 6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '5.x'
+  dotnetSdkVersion: '6.x'
 
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
@tpetchel Bump branch models-package to use dotnet 6.x for the Pipeline 
Reference: https://docs.microsoft.com/en-us/learn/modules/manage-build-dependencies/6-consume-package