### PR TITLE
Bump Pipeline dotnet version from 5 to 6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 variables:
   buildConfiguration: 'Release'
   wwwrootDir: 'Tailspin.SpaceGame.Web/wwwroot'
-  dotnetSdkVersion: '5.x'
+  dotnetSdkVersion: '6.x'
 
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
@tpetchel Bump dotnet version used in Pipeline from 5.x to 6.x
Referenced exercise: https://docs.microsoft.com/en-us/learn/modules/host-build-agent/5-build-application