### PR TITLE
Bugfix/home page typo

### DIFF
--- a/Tailspin.SpaceGame.Web/Views/Home/Index.cshtml
+++ b/Tailspin.SpaceGame.Web/Views/Home/Index.cshtml
@@ -6,6 +6,7 @@
     <div class="container">
         <img class="title" src="/images/space-game-title.svg" alt="Space Game">
         <p>An example site for learning</p>
+        <p>Welcome to the oficial Space Game site!</p>
     </div>
 </section>
 <section class="download">

--- a/Tailspin.SpaceGame.Web/Views/Home/Index.cshtml
+++ b/Tailspin.SpaceGame.Web/Views/Home/Index.cshtml
@@ -6,7 +6,7 @@
     <div class="container">
         <img class="title" src="/images/space-game-title.svg" alt="Space Game">
         <p>An example site for learning</p>
-        <p>Welcome to the oficial Space Game site!</p>
+        <p>Welcome to the official Space Game site!</p>
     </div>
 </section>
 <section class="download">


### PR DESCRIPTION
This PR fixes the typo 'oficial' → 'official' on the home page welcome message.